### PR TITLE
fix: load tabitem scripts from www directory

### DIFF
--- a/www/funs.R
+++ b/www/funs.R
@@ -1,0 +1,1 @@
+# Placeholder for common functions

--- a/www/tabitem_data.R
+++ b/www/tabitem_data.R
@@ -1,0 +1,1 @@
+# Placeholder for tab item data module

--- a/www/tabitem_info.R
+++ b/www/tabitem_info.R
@@ -1,0 +1,1 @@
+# Placeholder for tab item info module

--- a/www/tabitem_moddata.R
+++ b/www/tabitem_moddata.R
@@ -1,0 +1,1 @@
+# Placeholder for tab item modified data module


### PR DESCRIPTION
## Summary
- replace placeholder `www` file with a directory
- add tabitem script placeholders under `www`
- keep `global.R` sourcing the scripts from `www`

## Testing
- `Rscript -e "source('global.R')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841cd494de08324857b97fbe8557e1a