### PR TITLE
Add test for generateKableTable function

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,3 @@
+library(testthat)
+
+test_dir("tests/testthat")

--- a/tests/testthat/test_generate_kable_table.R
+++ b/tests/testthat/test_generate_kable_table.R
@@ -1,0 +1,23 @@
+library(testthat)
+library(dplyr)
+library(kableExtra)
+library(knitr)
+
+source("www/funs.R")
+
+test_that("generateKableTable handles empty data frame", {
+  out <- generateKableTable(data.frame(), format = "html")
+  output_str <- paste(out, collapse = "")
+  expect_true(grepl("No data available", output_str))
+})
+
+test_that("generateKableTable formats Pass/Fail correctly", {
+  df <- data.frame(Sample = c("A", "B"),
+                   X = c(1.0, 1.0),
+                   Y = c(1.0, 2.0),
+                   PassFail = c("PASS", "FAIL"))
+  out <- generateKableTable(df, format = "html")
+  output_str <- paste(out, collapse = "")
+  expect_true(grepl("#28a745", output_str))
+  expect_true(grepl("#dc3545", output_str))
+})

--- a/tests/testthat/test_generate_kable_table.R
+++ b/tests/testthat/test_generate_kable_table.R
@@ -3,7 +3,7 @@ library(dplyr)
 library(kableExtra)
 library(knitr)
 
-source("www/funs.R")
+source("../../www/funs.R")
 
 test_that("generateKableTable handles empty data frame", {
   out <- generateKableTable(data.frame(), format = "html")
@@ -18,6 +18,6 @@ test_that("generateKableTable formats Pass/Fail correctly", {
                    PassFail = c("PASS", "FAIL"))
   out <- generateKableTable(df, format = "html")
   output_str <- paste(out, collapse = "")
-  expect_true(grepl("#28a745", output_str))
-  expect_true(grepl("#dc3545", output_str))
+  expect_true(grepl("rgba\\(40, 167, 69", output_str))
+  expect_true(grepl("rgba\\(220, 53, 69", output_str))
 })


### PR DESCRIPTION
## Summary
- create testthat infrastructure
- add tests checking generateKableTable's empty and populated data frame behavior

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: there is no package called 'testthat')*

------
https://chatgpt.com/codex/tasks/task_e_6841d7ebf7fc8324b294d3021d30419e