### PR TITLE
Add APTT limit option

### DIFF
--- a/server.R
+++ b/server.R
@@ -40,6 +40,7 @@ shinyServer(function(input, output, session) {
                                       "Factors" = 0.15,
                                       "AntiXa" = 0.20,
                                       "DTIBI" = 0.20,
+                                      "APTT" = 0.20,
                                       "SpecialCoag" = 0.15
       )) # Retrieve the user-defined limit value
       
@@ -76,6 +77,7 @@ shinyServer(function(input, output, session) {
                             "Factors" = "Factors - 15%",
                             "AntiXa" = "Anti-Xa Parameter - 20%",
                             "DTIBI" = "DTIBI Parameter - 20%",
+                            "APTT" = "APTT - 20%",
                             "SpecialCoag" = "Special Coag Testing - 15%"
     )
     

--- a/www/tabitem_data.R
+++ b/www/tabitem_data.R
@@ -8,6 +8,7 @@ tabItem_data <- function() {
                                       "Factors - 15%" = "Factors",
                                       "Anti-Xa Parameter - 20%" = "AntiXa",
                                       "DTIBI Parameter - 20%" = "DTIBI",
+                                      "APTT - 20%" = "APTT",
                                       "Special Coag Testing - 15%" = "SpecialCoag")),
               # Adding new inputs within the same box
               textInput('testInput', label = 'Test:'),


### PR DESCRIPTION
## Summary
- add APTT option to limit percentage dropdown
- support APTT in server-side switch logic

## Testing
- `Rscript tests/testthat.R` *(fails: there is no package called 'testthat')*

------
https://chatgpt.com/codex/tasks/task_e_6841f5822ff083248872da7772cbc948