### PR TITLE
Simplify test workflow dependencies

### DIFF
--- a/.github/workflows/r-test.yaml
+++ b/.github/workflows/r-test.yaml
@@ -14,12 +14,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          install.packages('devtools')
-          devtools::install_deps(dependencies = TRUE)
+          install.packages(c('dplyr', 'kableExtra', 'knitr', 'testthat'))
         shell: Rscript {0}
 
       - name: Run tests
         run: |
-          install.packages('testthat')
           testthat::test_dir("tests/testthat")
         shell: Rscript {0}


### PR DESCRIPTION
## Summary
- streamline the GitHub Actions workflow to only install required packages

## Testing
- `Rscript -e "install.packages(c('dplyr','kableExtra','knitr','testthat'), repos='https://cran.rstudio.com')"` *(fails: packages are not available)*

------
https://chatgpt.com/codex/tasks/task_e_684a27bc12548324b35bf32a867f7194