### PR TITLE
Fix rhandsontable call validation

### DIFF
--- a/server.R
+++ b/server.R
@@ -203,10 +203,14 @@ observe({
 
 
   output$hot <- renderRHandsontable({
-    a <- vals$final_data 
-    rhandsontable(a
-                  , height = 482
-                  , rowHeaders = NULL) %>%
+    a <- vals$final_data
+    if (is.null(a) || !is.data.frame(a) || ncol(a) < 3) {
+      shiny::showNotification("Invalid table data", type = "error")
+      return(NULL)
+    }
+    rhandsontable(a,
+                  height = 482,
+                  rowHeaders = NULL) %>%
       hot_col(col = colnames(a)[1]) %>%
       hot_col(col = colnames(a)[2], format = '0.00', type = 'numeric') %>%
       hot_col(col = colnames(a)[3], format = '0.00', type = 'numeric') %>%


### PR DESCRIPTION
## Summary
- ensure `vals$final_data` is a valid data frame before rendering

## Testing
- `R -q -e 'library(testthat); test_dir("tests/testthat")'` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6b4e3fd08324a290ba56338fdafc